### PR TITLE
Minor improvements

### DIFF
--- a/src/GpsPicker.php
+++ b/src/GpsPicker.php
@@ -214,8 +214,7 @@ abstract class GpsPicker extends BaseControl
 	{
 		$control = parent::getControl();
 		$container = Html::el('div');
-		$id = $control->id;
-		$name = $control->name;
+		$container->id = $control->id;
 
 		if (!$onlyContainer) {
 			if ($this->showSearch) {


### PR DESCRIPTION
Fixed this issue:

``` php
$gpsPicker = $form->addGpsPicker("location", "Location")
                ->setDefaultValue(array(48, 18, "Address 1")); // this had been used

$gpsPicker->getSearchControlPrototype()->size(50);
$gpsPicker->setDefaultValue(array(48, 18, "Address 2")); // this had not have effect
```

Next, value set by `setHtmlId()` is now set to the control's div container.
