### PR TITLE
Fixed CSS rule insertion

### DIFF
--- a/client/nette.gpsPicker.js
+++ b/client/nette.gpsPicker.js
@@ -347,8 +347,16 @@ var GpsPicker = function () {
 		];
 		var stylesheet = window.document.styleSheets[0];
 		var method = stylesheet.cssRules ? 'insertRule' : 'addRule';
+		var cssRules = stylesheet.cssRules || stylesheet.rules;
+		var index = 0;
+		for (var i = 0; i < cssRules.length; i++) {
+			if (cssRules[i].type !== CSSRule.IMPORT_RULE && cssRules[i].type !== CSSRule.CHARSET_RULE) {
+				break;
+			}
+			index++;
+		}
 		for (var i = 0; i < rules.length; i++) {
-			stylesheet[method].call(stylesheet,	 rules[i], 0);
+			stylesheet[method].call(stylesheet, rules[i], index++);
 		}
 
 		if (Nette) {


### PR DESCRIPTION
Trying to prepend a CSS rule before `@charset` and/or `@import` rules results in an uncaught HierarchyRequestError. According to the specs, nothing can precede these two types of rules. I find the first non-import non-charset rule and insert at that offset. Could somebody please test this on IE < 9?

btw what's the reason behind _prepending_ the rule? Couldn't it just be inserted at `cssRules.length` offset? It would make this whole thing much simpler :)
